### PR TITLE
Pin GitHub Actions to latest releases with SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: "dzil run"
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: "Installing dependencies and testing all using dzil"
-        uses: jonasbn/github-action-perl-dist-zilla@0.5.5
+        uses: jonasbn/github-action-perl-dist-zilla@af6fe971d0c108254ccc8d215623278950a9b503 # 0.5.5
         with:
           dzil-arguments: 'test --all'


### PR DESCRIPTION
## Summary
This PR pins all GitHub Actions to their latest releases using commit SHAs for enhanced security, with human-readable version comments.

## Changes
- **actions/checkout**: Pinned to v6.0.1 (SHA: 8e8c483)
- **jonasbn/github-action-perl-dist-zilla**: Already at latest 0.5.5, now pinned with SHA (af6fe97)

## Benefits
- **Security**: Using commit SHAs prevents tag hijacking attacks
- **Stability**: Ensures consistent behavior across workflow runs
- **Maintainability**: Version comments make it easy to understand which version is pinned
- **Automation**: Dependabot can automatically update pinned actions

## Notes
Dependabot is configured to manage these dependencies and will create PRs when new versions are available.